### PR TITLE
remove bot.set_webhook

### DIFF
--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -160,14 +160,6 @@ class TelegramBotManager(LocaleMixin):
         if isinstance(config.get('webhook'), dict):
             self.logger.debug("Setting up webhook...")
             self.webhook = True
-            webhook_conf = config['webhook']
-            if webhook_conf.get('set_webhook'):
-                set_webhook = webhook_conf['set_webhook']
-                if set_webhook.get('certificate'):
-                    set_webhook['certificate'] = open(set_webhook['certificate'], 'rb')
-                self.logger.debug("Setting webhook URL...")
-                self.updater.bot.set_webhook(**set_webhook)
-                self.logger.debug("Webhook URL is set...")
             self.logger.debug("Webhook is set...")
 
         self.logger.debug("Checking connection to Telegram bot API...")


### PR DESCRIPTION
Since PTB 13.4, `updater.start_webhook` always calls `bot.set_webhook`. There is no need to call it manually. 
See PTB doc [here](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.updater.html?highlight=%27set_webhook%27#telegram.ext.Updater.start_webhook)

Thus users needn't a config dict named `webhook.set_webhook`, but a config named `webhook.start_webhook` only.

(BTW, document about webhook is missing)